### PR TITLE
then() accepts top-level functions by name and calls them implicitly

### DIFF
--- a/State/State.swift
+++ b/State/State.swift
@@ -42,6 +42,20 @@ public struct State<S, A> {
         return flatMap { _ in next }
     }
 
+    /// Given a top-level function returning a stateful computation, allow it to be passed by name instead of called explicity.
+    ///
+    /// Example::
+    ///
+    ///     // Instead of this
+    ///     put(newstate).then(get())
+    ///
+    ///     // Allows this
+    ///     put(newstate).then(get)
+    ///
+    public func then<B>(next: () -> State<S, B>) -> State<S, B> {
+        return then(next())
+    }
+
 
     // MARK: Higher order functions
 

--- a/StateTests/StateTests.swift
+++ b/StateTests/StateTests.swift
@@ -58,8 +58,8 @@ class StateTests: XCTestCase {
 
     func testGetAndPutAllowReadingStateAtDifferentPointsInTime() {
         let wrapString = get().flatMap { str in
-                         put("foo").then(get()).flatMap { foo in
-                         put("bar").then(get()).flatMap { bar in
+                         put("foo").then(get).flatMap { foo in
+                         put("bar").then(get).flatMap { bar in
                              put("\(foo), \(str), \(bar)")
                          }}}
 


### PR DESCRIPTION
Implements #5.
